### PR TITLE
Minor bitrot fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Simple benchmark to track the rough performance penalty incurred by dependency tracking.
 
+### Changed
+
+- The project now targets edition 2021
+
 ## [0.1.2] - 2021-05-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tracing-mutex"
 version = "0.1.2"
 authors = ["Bert Peters <bert@bertptrs.nl>"]
-edition = "2018"
+edition = "2021"
 license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/tracing-mutex"
 categories = ["concurrency", "development-tools::debugging"]

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,3 @@
-use std::array::IntoIter;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -116,7 +115,7 @@ where
 
         if lb < ub {
             // This edge might introduce a cycle, need to recompute the topological sort
-            let mut visited = IntoIter::new([x, y]).collect();
+            let mut visited = IntoIterator::into_iter([x, y]).collect();
             let mut delta_f = Vec::new();
             let mut delta_b = Vec::new();
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -115,7 +115,7 @@ where
 
         if lb < ub {
             // This edge might introduce a cycle, need to recompute the topological sort
-            let mut visited = IntoIterator::into_iter([x, y]).collect();
+            let mut visited = [x, y].into_iter().collect();
             let mut delta_f = Vec::new();
             let mut delta_b = Vec::new();
 

--- a/src/stdsync.rs
+++ b/src/stdsync.rs
@@ -97,7 +97,7 @@ pub struct TracingMutex<T> {
 #[derive(Debug)]
 pub struct TracingMutexGuard<'a, T> {
     inner: MutexGuard<'a, T>,
-    mutex: BorrowedMutex<'a>,
+    _mutex: BorrowedMutex<'a>,
 }
 
 fn map_lockresult<T, I, F>(result: LockResult<I>, mapper: F) -> LockResult<T>
@@ -144,7 +144,7 @@ impl<T> TracingMutex<T> {
         let result = self.inner.lock();
 
         let mapper = |guard| TracingMutexGuard {
-            mutex,
+            _mutex: mutex,
             inner: guard,
         };
 
@@ -163,7 +163,7 @@ impl<T> TracingMutex<T> {
         let result = self.inner.try_lock();
 
         let mapper = |guard| TracingMutexGuard {
-            mutex,
+            _mutex: mutex,
             inner: guard,
         };
 
@@ -227,7 +227,7 @@ pub struct TracingRwLock<T> {
 #[derive(Debug)]
 pub struct TracingRwLockGuard<'a, L> {
     inner: L,
-    mutex: BorrowedMutex<'a>,
+    _mutex: BorrowedMutex<'a>,
 }
 
 /// Wrapper around [`std::sync::RwLockReadGuard`].
@@ -254,7 +254,10 @@ impl<T> TracingRwLock<T> {
         let mutex = self.id.get_borrowed();
         let result = self.inner.read();
 
-        map_lockresult(result, |inner| TracingRwLockGuard { inner, mutex })
+        map_lockresult(result, |inner| TracingRwLockGuard {
+            inner,
+            _mutex: mutex,
+        })
     }
 
     /// Wrapper for [`std::sync::RwLock::write`].
@@ -268,7 +271,10 @@ impl<T> TracingRwLock<T> {
         let mutex = self.id.get_borrowed();
         let result = self.inner.write();
 
-        map_lockresult(result, |inner| TracingRwLockGuard { inner, mutex })
+        map_lockresult(result, |inner| TracingRwLockGuard {
+            inner,
+            _mutex: mutex,
+        })
     }
 
     /// Wrapper for [`std::sync::RwLock::try_read`].
@@ -282,7 +288,10 @@ impl<T> TracingRwLock<T> {
         let mutex = self.id.get_borrowed();
         let result = self.inner.try_read();
 
-        map_trylockresult(result, |inner| TracingRwLockGuard { inner, mutex })
+        map_trylockresult(result, |inner| TracingRwLockGuard {
+            inner,
+            _mutex: mutex,
+        })
     }
 
     /// Wrapper for [`std::sync::RwLock::try_write`].
@@ -296,7 +305,10 @@ impl<T> TracingRwLock<T> {
         let mutex = self.id.get_borrowed();
         let result = self.inner.try_write();
 
-        map_trylockresult(result, |inner| TracingRwLockGuard { inner, mutex })
+        map_trylockresult(result, |inner| TracingRwLockGuard {
+            inner,
+            _mutex: mutex,
+        })
     }
 
     /// Return a mutable reference to the underlying data.


### PR DESCRIPTION
The compiler has gotten a bit smarter so new warnings have popped up. This PR addresses:

- The deprecation of `IntoIter::new` in favour of `IntoIterator::into_iter`
- Derived traits no longer counting for "usage" of otherwise unused fields.