### PR TITLE
Prepare for release 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-features -- -D warnings
+          args: --all-features --all-targets -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 - Generic support for wrapping mutexes that implement the traits provided by the
   [`lock_api`][lock_api] crate. This can be used for creating support for other mutex providers that
@@ -15,6 +17,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   provided mutex types as well as a dedicated `Once` wrapper.
 
 - Simple benchmark to track the rough performance penalty incurred by dependency tracking.
+
+### Breaking
+
+- The library now requires edition 2021.
+
+- The `Mutex`- and `RwLockGuards` now dereference to `T` rather than the lock guard they wrap. This
+  is technically a bugfix but can theoretically break existing code.
+
+- Self-cycles are no longer allowed for lock dependencies. They previously were because it usually
+  isn't a problem, but it can create RWR deadlocks with `RwLocks`.
 
 ### Changed
 
@@ -43,8 +55,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[Unreleased]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.2...HEAD
-[0.1.2]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.2...v0.1.2
+[Unreleased]: https://github.com/bertptrs/tracing-mutex/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.2...v0.2.0
+[0.1.2]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bertptrs/tracing-mutex/releases/tag/v0.1.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-mutex"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Bert Peters <bert@bertptrs.nl>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -227,6 +227,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_no_self_cycle() {
+        // Regression test for https://github.com/bertptrs/tracing-mutex/issues/7
+        let mut graph = DiGraph::default();
+
+        assert!(!graph.add_edge(1, 1));
+    }
+
+    #[test]
     fn test_digraph() {
         let mut graph = DiGraph::default();
 

--- a/src/parkinglot.rs
+++ b/src/parkinglot.rs
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn test_rwlock_upgradable_read_usage() {
-        let lock = Arc::new(TracingRwLock::new(()));
+        let lock = TracingRwLock::new(());
 
         // Should be able to acquire an upgradable read lock.
         let upgradable_guard: TracingRwLockUpgradableReadGuard<'_, _> = lock.upgradable_read();

--- a/src/stdsync.rs
+++ b/src/stdsync.rs
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_mutex_usage() {
-        let mutex = Arc::new(TracingMutex::new((0)));
+        let mutex = Arc::new(TracingMutex::new(0));
 
         assert_eq!(*mutex.lock().unwrap(), 0);
         *mutex.lock().unwrap() = 1;
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn test_rwlock_usage() {
-        let rwlock = Arc::new(TracingRwLock::new((0)));
+        let rwlock = Arc::new(TracingRwLock::new(0));
 
         assert_eq!(*rwlock.read().unwrap(), 0);
         assert_eq!(*rwlock.write().unwrap(), 0);


### PR DESCRIPTION
Minor changes to prepare for release:

- Fix minor code style issues in tests
- Ensure code with warnings no longer passes CI
- Explicitly test for disallowing self-cycles to prevent regressions
- Update version and README