### PR TITLE
Fix documentation builds for features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 name: Continuous integration
 
 jobs:
-  ci:
+  tests:
     name: Rust project
     runs-on: ubuntu-latest
     strategy:
@@ -47,3 +47,22 @@ jobs:
         with:
           command: clippy
           args: --all-features --all-targets -- -D warnings
+
+  docs:
+    name: Documentation build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Build documentation
+        env:
+          # Build the docs like docs.rs builds it
+          RUSTDOCFLAGS: --cfg docsrs
+        run: cargo doc --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
 - Build [docs.rs] documentation with all features enabled for completeness.
+
+### Fixed
+
+- The `parkinglot` module is now correctly enabled by the `parkinglot` feature rather than the
+  `lockapi` feature.
 
 ## [0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Build [docs.rs] documentation with all features enabled for completeness.
+
 ## [0.2.0]
 
 ### Added
@@ -61,5 +65,6 @@ Initial release.
 [0.1.1]: https://github.com/bertptrs/tracing-mutex/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/bertptrs/tracing-mutex/releases/tag/v0.1.0
 
+[docs.rs]: https://docs.rs/tracing-mutex/latest/tracing_mutex/
 [lock_api]: https://docs.rs/lock_api/
 [parking_lot]: https://docs.rs/parking_lot/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ repository = "https://github.com/bertptrs/tracing-mutex"
 [package.metadata.docs.rs]
 # Build docs for all features so the documentation is more complete
 all-features = true
+# Set custom cfg so we can enable docs.rs magic
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ description = "Ensure deadlock-free mutexes by allocating in order, or else."
 readme = "README.md"
 repository = "https://github.com/bertptrs/tracing-mutex"
 
+[package.metadata.docs.rs]
+# Build docs for all features so the documentation is more complete
+all-features = true
+
 [dependencies]
 lazy_static = "1"
 lock_api = { version = "0.4", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //! enabled, and to the underlying mutex when they're not.
 //!
 //! [paper]: https://whileydave.com/publications/pk07_jea/
+#![cfg_attr(docsrs, feature(doc_cfg))]
 use std::cell::RefCell;
 use std::cell::UnsafeCell;
 use std::fmt;
@@ -61,16 +62,20 @@ use std::sync::PoisonError;
 
 use lazy_static::lazy_static;
 #[cfg(feature = "lockapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lockapi")))]
 pub use lock_api;
 #[cfg(feature = "parkinglot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "parkinglot")))]
 pub use parking_lot;
 
 use crate::graph::DiGraph;
 
 mod graph;
 #[cfg(feature = "lockapi")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lockapi")))]
 pub mod lockapi;
-#[cfg(feature = "lockapi")]
+#[cfg(feature = "parkinglot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "parkinglot")))]
 pub mod parkinglot;
 pub mod stdsync;
 


### PR DESCRIPTION
Fixes an oversight where documentation for feature-gated modules was not built properly. Also fixes an issue where the `parkinglot` module would be enabled without all of its dependencies.