### PR TITLE
Add a wrapper for `std::sync::Condvar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Build [docs.rs] documentation with all features enabled for completeness.
+- Add support for `std::sync::Condvar`
 
 ### Fixed
 


### PR DESCRIPTION
This wrapper does not do any tracing itself but supports the use of a tracing mutex guard instead of an `std::sync` one.