### PR TITLE
Implement OnceLock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - "1.63" # minimum stable rust version
+          - "1.70" # minimum stable rust version
           - stable
           - beta
           - nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- The minimum supported Rust version is now defined as 1.63. Previously it was undefined.
+- The minimum supported Rust version is now defined as 1.70. Previously it was undefined.
 - Wrappers for `std::sync` primitives can now be `const` constructed.
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - The minimum supported Rust version is now defined as 1.70. Previously it was undefined.
 - Wrappers for `std::sync` primitives can now be `const` constructed.
+- Add support for `std::sync::OnceLock`
 
 ### Breaking
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-lazy_static = "1"
 lock_api = { version = "0.4", optional = true }
 parking_lot = { version = "0.12", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["mutex", "rwlock", "once", "thread"]
 description = "Ensure deadlock-free mutexes by allocating in order, or else."
 readme = "README.md"
 repository = "https://github.com/bertptrs/tracing-mutex"
-rust-version = "1.63"
+rust-version = "1.70"
 
 [package.metadata.docs.rs]
 # Build docs for all features so the documentation is more complete

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ performance penalty in your production environment, this library also offers deb
 when debug assertions are enabled, and to `Mutex` when they are not. Similar helper types are
 available for other synchronization primitives.
 
-The minimum supported Rust version is 1.63. Increasing this is not considered a breaking change, but
+The minimum supported Rust version is 1.70. Increasing this is not considered a breaking change, but
 will be avoided within semver-compatible releases if possible.
 
 ### Features

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
 status = [
-    'Rust project (1.63)',
+    'Rust project (1.70)',
     'Rust project (stable)',
     'Rust project (beta)',
     'Documentation build',


### PR DESCRIPTION
1.70 brought `OnceLock`. This needs a new wrapper and should replace all usage of `lazy_static!`, as well as the current internal implementation of OnceLock.