### PR TITLE
Clean up Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           toolchain: "1.70"
 
       # Test everything except experimental features.
-      - run: cargo test --features backtraces,lockapi,parkinglot
+      - run: cargo test --features backtraces,lock_api,parking_lot
 
   docs:
     name: Documentation build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
 
       # Make sure we test with recent deps
       - run: cargo update
+        # Note: some crates broke BC with 1.74 so we use the locked deps
+        if: "${{ matrix.rust != '1.74' }}"
       - run: cargo build --all-features --all-targets
       - run: cargo test --all-features
       - run: cargo fmt --all -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ lock_api = ["dep:lock_api"]
 parking_lot = ["dep:parking_lot", "lock_api"]
 
 # Deprecated feature names from when cargo couldn't distinguish between dep and feature
-lockapi = ["lock_api"]
-parkinglot = ["parking_lot"]
+lockapi = ["dep:lock_api"]
+parkinglot = ["dep:parking_lot", "lock_api"]
 
 [build-dependencies]
 autocfg = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,12 @@ required-features = ["parkinglot"]
 default = ["backtraces"]
 backtraces = []
 experimental = []
-# Feature names do not match crate names pending namespaced features.
+lock_api = ["dep:lock_api"]
+parking_lot = ["dep:parking_lot", "lock_api"]
+
+# Deprecated feature names from when cargo couldn't distinguish between dep and feature
 lockapi = ["lock_api"]
-parkinglot = ["parking_lot", "lockapi"]
+parkinglot = ["parking_lot"]
 
 [build-dependencies]
 autocfg = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,11 +84,19 @@ use std::sync::MutexGuard;
 use std::sync::OnceLock;
 use std::sync::PoisonError;
 
-#[cfg(feature = "lockapi")]
-#[cfg_attr(docsrs, doc(cfg(feature = "lockapi")))]
+#[cfg(feature = "lock_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
+#[cfg_attr(
+    all(not(docsrs), feature = "lockapi"),
+    deprecated = "The `lockapi` feature has been renamed `lock_api`"
+)]
 pub use lock_api;
-#[cfg(feature = "parkinglot")]
-#[cfg_attr(docsrs, doc(cfg(feature = "parkinglot")))]
+#[cfg(feature = "parking_lot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+#[cfg_attr(
+    all(not(docsrs), feature = "parkinglot"),
+    deprecated = "The `parkinglot` feature has been renamed `parking_lot`"
+)]
 pub use parking_lot;
 use reporting::Dep;
 use reporting::Reportable;
@@ -96,11 +104,19 @@ use reporting::Reportable;
 use crate::graph::DiGraph;
 
 mod graph;
-#[cfg(feature = "lockapi")]
-#[cfg_attr(docsrs, doc(cfg(feature = "lockapi")))]
+#[cfg(feature = "lock_api")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
+#[cfg_attr(
+    all(not(docsrs), feature = "lockapi"),
+    deprecated = "The `lockapi` feature has been renamed `lock_api`"
+)]
 pub mod lockapi;
-#[cfg(feature = "parkinglot")]
-#[cfg_attr(docsrs, doc(cfg(feature = "parkinglot")))]
+#[cfg(feature = "parking_lot")]
+#[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+#[cfg_attr(
+    all(not(docsrs), feature = "parkinglot"),
+    deprecated = "The `parkinglot` feature has been renamed `parking_lot`"
+)]
 pub mod parkinglot;
 mod reporting;
 pub mod stdsync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,36 +85,30 @@ use std::sync::OnceLock;
 use std::sync::PoisonError;
 
 #[cfg(feature = "lock_api")]
-#[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
-#[cfg_attr(
-    all(not(docsrs), feature = "lockapi"),
-    deprecated = "The `lockapi` feature has been renamed `lock_api`"
-)]
+#[cfg_attr(docsrs, doc(cfg(feature = "lockapi")))]
+#[deprecated = "The top-level re-export `lock_api` is deprecated. Use `tracing_mutex::lockapi::raw` instead"]
 pub use lock_api;
 #[cfg(feature = "parking_lot")]
-#[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
-#[cfg_attr(
-    all(not(docsrs), feature = "parkinglot"),
-    deprecated = "The `parkinglot` feature has been renamed `parking_lot`"
-)]
+#[cfg_attr(docsrs, doc(cfg(feature = "parkinglot")))]
+#[deprecated = "The top-level re-export `parking_lot` is deprecated. Use `tracing_mutex::parkinglot::raw` instead"]
 pub use parking_lot;
+
+use graph::DiGraph;
 use reporting::Dep;
 use reporting::Reportable;
 
-use crate::graph::DiGraph;
-
 mod graph;
-#[cfg(feature = "lock_api")]
+#[cfg(any(feature = "lock_api", feature = "lockapi"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "lock_api")))]
 #[cfg_attr(
-    all(not(docsrs), feature = "lockapi"),
+    all(not(docsrs), feature = "lockapi", not(feature = "lock_api")),
     deprecated = "The `lockapi` feature has been renamed `lock_api`"
 )]
 pub mod lockapi;
-#[cfg(feature = "parking_lot")]
+#[cfg(any(feature = "parking_lot", feature = "parkinglot"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
 #[cfg_attr(
-    all(not(docsrs), feature = "parkinglot"),
+    all(not(docsrs), feature = "parkinglot", not(feature = "parking_lot")),
     deprecated = "The `parkinglot` feature has been renamed `parking_lot`"
 )]
 pub mod parkinglot;

--- a/src/lockapi.rs
+++ b/src/lockapi.rs
@@ -8,6 +8,7 @@
 //! Wrapped mutexes are at least one `usize` larger than the types they wrapped, and must be aligned
 //! to `usize` boundaries. As such, libraries with many mutexes may want to consider the additional
 //! required memory.
+pub use lock_api as raw;
 use lock_api::GuardNoSend;
 use lock_api::RawMutex;
 use lock_api::RawMutexFair;


### PR DESCRIPTION
Related to #43

Includes a couple Cargo changes that I've been wanting to fix:

- Rename the features to the name of their crates. Keep the old names but deprecate them so we can remove them in 0.4.
- Deprecate old feature banes
- Deprecate top-level reexports