### PR TITLE
Prepare for release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.2]
+
 ### Fixed
 
 - `std::sync` wrappers now no longer incorrectly require `T: Sized`
@@ -132,7 +134,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Initial release.
 
-[Unreleased]: https://github.com/bertptrs/tracing-mutex/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/bertptrs/tracing-mutex/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/bertptrs/tracing-mutex/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/bertptrs/tracing-mutex/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/bertptrs/tracing-mutex/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/bertptrs/tracing-mutex/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-mutex"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "autocfg",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-mutex"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["concurrency", "development-tools::debugging"]


### PR DESCRIPTION
This is a bugfix release and contains no new functionality.