### PR TITLE
Miscellaneous CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
         if: "${{ matrix.rust != '1.74' }}"
       - run: cargo build --all-features --all-targets
       - run: cargo test --all-features
-      - run: cargo fmt --all -- --check
         # Note: Rust 1.74 doesn't understand edition 2024 formatting so no point
         if: "${{ matrix.rust != '1.74' }}"
       - run: cargo clippy --all-features --all-targets -- -D warnings
@@ -67,4 +66,4 @@ jobs:
         env:
           # Build the docs like docs.rs builds it
           RUSTDOCFLAGS: --cfg docsrs
-        run: cargo doc --all-features
+        run: cargo doc --all-features --no-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          components: rustfmt, clippy
+          components: clippy
 
       # Make sure we test with recent deps
       - run: cargo update
@@ -44,12 +44,23 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.74
         with:
           toolchain: "1.70"
 
       # Test everything except experimental features.
       - run: cargo test --features backtraces,lock_api,parking_lot
+
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      # Use nightly formatting options
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
 
   docs:
     name: Documentation build
@@ -58,9 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: nightly
+      - uses: dtolnay/rust-toolchain@nightly
 
       - name: Build documentation
         env:

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 style_edition="2024"
+imports_granularity="Item"

--- a/src/parkinglot.rs
+++ b/src/parkinglot.rs
@@ -47,6 +47,8 @@ pub use parking_lot::WaitTimeoutResult;
 
 pub mod tracing;
 
+// Skip reformatting the combined imports as it duplicates the guards
+#[rustfmt::skip]
 #[cfg(debug_assertions)]
 pub use tracing::{
     FairMutex, FairMutexGuard, MappedFairMutexGuard, MappedMutexGuard, MappedReentrantMutexGuard,
@@ -56,6 +58,7 @@ pub use tracing::{
     const_reentrant_mutex, const_rwlock,
 };
 
+#[rustfmt::skip]
 #[cfg(not(debug_assertions))]
 pub use parking_lot::{
     FairMutex, FairMutexGuard, MappedFairMutexGuard, MappedMutexGuard, MappedReentrantMutexGuard,

--- a/src/stdsync.rs
+++ b/src/stdsync.rs
@@ -20,11 +20,14 @@
 //! ```
 pub use std::sync as raw;
 
+// Skip reformatting the combined imports as it duplicates the guards
+#[rustfmt::skip]
 #[cfg(not(debug_assertions))]
 pub use std::sync::{
     Condvar, Mutex, MutexGuard, Once, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard,
 };
 
+#[rustfmt::skip]
 #[cfg(debug_assertions)]
 pub use tracing::{
     Condvar, Mutex, MutexGuard, Once, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard,


### PR DESCRIPTION
This fixes a build issue where recent versions of `lock_api` fail to build documentation on the nightly compiler, and enforces the style guide as it exists in this project.