### PR TITLE
Allow user-specified cycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- (experimental) allow the library consumer to override what should happen when the system detects a
+  cycle.
+
 ## [0.3.2]
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ mod reporting;
 pub mod stdsync;
 pub mod util;
 
+#[cfg(feature = "experimental")]
+pub use reporting::{set_panic_action, PanicAction};
+
 thread_local! {
     /// Stack to track which locks are held
     ///
@@ -188,7 +191,7 @@ impl MutexId {
         });
 
         if let Some(cycle) = opt_cycle {
-            panic!("{}", Dep::panic_message(&cycle))
+            reporting::report_cycle(&cycle);
         }
 
         HELD_LOCKS.with(|locks| locks.borrow_mut().push(self.value()));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,6 @@ mod reporting;
 pub mod stdsync;
 pub mod util;
 
-#[cfg(feature = "experimental")]
-pub use reporting::{set_panic_action, PanicAction};
-
 thread_local! {
     /// Stack to track which locks are held
     ///

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -6,6 +6,8 @@ use std::backtrace::Backtrace;
 use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
 
 #[cfg(feature = "backtraces")]
 pub type Dep = MutexDep<Arc<Backtrace>>;
@@ -15,12 +17,44 @@ pub type Dep = MutexDep<()>;
 // Base message to be reported when cycle is detected
 const BASE_MESSAGE: &str = "Found cycle in mutex dependency graph:";
 
+/// Action to take when a cycle is detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PanicAction {
+    /// Panic when a cycle is detected.
+    Panic = 0,
+    /// Log the cycle to stderr but do not panic.
+    #[cfg(feature = "experimental")]
+    Log = 1,
+}
+
+static PANIC_ACTION: AtomicU8 = AtomicU8::new(0);
+
+/// Set the action to take when a cycle is detected.
+///
+/// This is useful for incrementally adopting tracing-mutex to a large codebase compiled with
+/// `panic=abort`, as it allows you to continue running your program even when a cycle is detected.
+#[cfg(feature = "experimental")]
+pub fn set_panic_action(action: PanicAction) {
+    PANIC_ACTION.store(action as u8, Ordering::Relaxed);
+}
+
+pub(crate) fn report_cycle(cycle: &[Dep]) {
+    let message = Dep::message(cycle);
+    let action = PANIC_ACTION.load(Ordering::Relaxed);
+    if action == PanicAction::Panic as u8 {
+        panic!("{message}");
+    } else {
+        eprintln!("{message}");
+    }
+}
+
 pub trait Reportable: Clone {
     /// Capture the current state
     fn capture() -> Self;
 
     /// Format a trace of state for human readable consumption.
-    fn panic_message(trace: &[Self]) -> Cow<'static, str>;
+    fn message(trace: &[Self]) -> Cow<'static, str>;
 }
 
 #[derive(Clone)]
@@ -35,7 +69,7 @@ impl Reportable for MutexDep<()> {
         Self(())
     }
 
-    fn panic_message(_trace: &[Self]) -> Cow<'static, str> {
+    fn message(_trace: &[Self]) -> Cow<'static, str> {
         Cow::Borrowed(BASE_MESSAGE)
     }
 }
@@ -52,7 +86,7 @@ impl Reportable for MutexDep<Arc<Backtrace>> {
         Self(Arc::new(Backtrace::capture()))
     }
 
-    fn panic_message(trace: &[Self]) -> Cow<'static, str> {
+    fn message(trace: &[Self]) -> Cow<'static, str> {
         let mut message = format!("{BASE_MESSAGE}\n");
 
         for entry in trace {

--- a/src/reporting.rs
+++ b/src/reporting.rs
@@ -6,46 +6,33 @@ use std::backtrace::Backtrace;
 use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::Arc;
-use std::sync::atomic::AtomicU8;
-use std::sync::atomic::Ordering;
+use std::sync::Mutex;
+use std::sync::MutexGuard;
+use std::sync::PoisonError;
 
 #[cfg(feature = "backtraces")]
 pub type Dep = MutexDep<Arc<Backtrace>>;
 #[cfg(not(feature = "backtraces"))]
 pub type Dep = MutexDep<()>;
 
+pub(crate) type CycleHandler = Option<Box<dyn FnMut(&str) + Send + Sync>>;
+
 // Base message to be reported when cycle is detected
 const BASE_MESSAGE: &str = "Found cycle in mutex dependency graph:";
 
-/// Action to take when a cycle is detected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(u8)]
-pub enum PanicAction {
-    /// Panic when a cycle is detected.
-    Panic = 0,
-    /// Log the cycle to stderr but do not panic.
-    #[cfg(feature = "experimental")]
-    Log = 1,
-}
+pub(crate) fn cycle_handler_storage() -> MutexGuard<'static, CycleHandler> {
+    static CYCLE_HANDLER: Mutex<CycleHandler> = Mutex::new(None);
 
-static PANIC_ACTION: AtomicU8 = AtomicU8::new(0);
-
-/// Set the action to take when a cycle is detected.
-///
-/// This is useful for incrementally adopting tracing-mutex to a large codebase compiled with
-/// `panic=abort`, as it allows you to continue running your program even when a cycle is detected.
-#[cfg(feature = "experimental")]
-pub fn set_panic_action(action: PanicAction) {
-    PANIC_ACTION.store(action as u8, Ordering::Relaxed);
+    CYCLE_HANDLER.lock().unwrap_or_else(PoisonError::into_inner)
 }
 
 pub(crate) fn report_cycle(cycle: &[Dep]) {
     let message = Dep::message(cycle);
-    let action = PANIC_ACTION.load(Ordering::Relaxed);
-    if action == PanicAction::Panic as u8 {
-        panic!("{message}");
+
+    if let Some(handler) = cycle_handler_storage().as_mut() {
+        handler(&message);
     } else {
-        eprintln!("{message}");
+        panic!("{message}");
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
 //! Utilities related to the internals of dependency tracking.
 use crate::MutexId;
+#[cfg(feature = "experimental")]
+#[cfg(feature = "experimental")]
+use crate::reporting::cycle_handler_storage;
 
 /// Reset the dependencies for the given entity.
 ///
@@ -42,6 +45,44 @@ use crate::MutexId;
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub unsafe fn reset_dependencies<T: Traced>(traced: &T) {
     crate::get_dependency_graph().remove_node(traced.get_id().value());
+}
+
+/// Install a new cycle handler
+///
+/// This function will be called whenever a cycle in the dependency graph is detected. The default
+/// handler will panic with a message describing the panic, but this can be downgraded to logging,
+/// or even some complicated reporting mechanism.
+///
+/// ```
+/// # use tracing_mutex::util::set_cycle_handler;
+/// let mut logged = false;
+///
+/// set_cycle_handler(move |message| {
+///     if !logged {
+///         logged = true;
+///         eprintln!("{message}");
+///     }
+/// });
+/// ```
+///
+/// This handler can be reset to its original state via [`reset_cycle_handler`].
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub fn set_cycle_handler<T>(handler: T)
+where
+    T: FnMut(&str) + Send + Sync + 'static,
+{
+    *cycle_handler_storage() = Some(Box::new(handler))
+}
+
+/// Reset cycle handler to its original state
+///
+/// This function returns `true` if a custom handler was previously installed, and `false`
+/// otherwise.
+#[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
+pub fn reset_cycle_handler() -> bool {
+    cycle_handler_storage().take().is_some()
 }
 
 /// Types that participate in dependency tracking


### PR DESCRIPTION
This PR is an edit of #53. I made a mistake and accidentally closed the PR while trying to update it. Apologies.

Changes compared to the original PR is that the new handler can be specified by the user.

I'm not 100% happy about the API as we are handing the handler a string rather than an object that can be properly introspected, but the alternative is to expose a lot of internals which isn't ideal either.